### PR TITLE
Add verify_cert option, set https by default, disable cert verification by default

### DIFF
--- a/src/hydrusvideodeduplicator/__main__.py
+++ b/src/hydrusvideodeduplicator/__main__.py
@@ -93,7 +93,11 @@ def main(api_key: Annotated[Optional[str], typer.Option(help="Hydrus API Key")] 
         error_connecting_exception_msg = "API Error"
         error_connecting_exception = exc
     except hydrus_api.ConnectionError as exc:
-        error_connecting_exception_msg = "Failed to connect to Hydrus. Is your Hydrus instance running?"
+        # Probably SSL error
+        if "SSL" in str(exc):
+            error_connecting_exception_msg = "Failed to connect to Hydrus. SSL certificate verification failed."
+        else:
+            error_connecting_exception_msg = "Failed to connect to Hydrus. Is your Hydrus instance running?"
         error_connecting_exception = exc
     else:
         error_connecting = False

--- a/src/hydrusvideodeduplicator/__main__.py
+++ b/src/hydrusvideodeduplicator/__main__.py
@@ -6,7 +6,7 @@ import hydrusvideodeduplicator.hydrus_api as hydrus_api
 from rich import print as rprint
 
 from .__about__ import __version__
-from .config import HYDRUS_API_KEY, HYDRUS_API_URL
+from .config import HYDRUS_API_KEY, HYDRUS_API_URL, REQUESTS_CA_BUNDLE
 from .dedup import HydrusVideoDeduplicator
 
 from .vpdq_util import VPDQ_QUERY_MATCH_THRESHOLD_PERCENT
@@ -29,8 +29,8 @@ def main(api_key: Annotated[Optional[str], typer.Option(help="Hydrus API Key")] 
         query: Annotated[Optional[List[str]], typer.Option(help="Custom Hydrus tag query")] = None,
         threshold: Annotated[Optional[float], typer.Option(help="Similarity threshold for a pair of videos where 100 is identical")] = VPDQ_QUERY_MATCH_THRESHOLD_PERCENT,
         skip_hashing: Annotated[Optional[bool], typer.Option(help="Skip perceptual hashing and just search for duplicates")] = False,
-        verify_cert: Annotated[Optional[bool], typer.Option(help="Require TLS cert to be verified for https")] = False,
-        verbose:  Annotated[Optional[bool], typer.Option(hidden=True)] = False,
+        verify_cert: Annotated[Optional[str], typer.Option(help="Path to TLS cert. This forces verification.")] = REQUESTS_CA_BUNDLE,
+        verbose:  Annotated[Optional[bool], typer.Option(help="Verbose logging")] = False,
         debug: Annotated[Optional[bool], typer.Option(hidden=True)] = False,
         ):
 
@@ -96,6 +96,9 @@ def main(api_key: Annotated[Optional[str], typer.Option(help="Hydrus API Key")] 
         # Probably SSL error
         if "SSL" in str(exc):
             error_connecting_exception_msg = "Failed to connect to Hydrus. SSL certificate verification failed."
+        # Probably tried using http instead of https when client is https
+        elif "Connection aborted" in str(exc):
+            error_connecting_exception_msg = "Failed to connect to Hydrus. Does your Hydrus Client API http/https setting match your --api-url?"
         else:
             error_connecting_exception_msg = "Failed to connect to Hydrus. Is your Hydrus instance running?"
         error_connecting_exception = exc

--- a/src/hydrusvideodeduplicator/__main__.py
+++ b/src/hydrusvideodeduplicator/__main__.py
@@ -29,6 +29,7 @@ def main(api_key: Annotated[Optional[str], typer.Option(help="Hydrus API Key")] 
         query: Annotated[Optional[List[str]], typer.Option(help="Custom Hydrus tag query")] = None,
         threshold: Annotated[Optional[float], typer.Option(help="Similarity threshold for a pair of videos where 100 is identical")] = VPDQ_QUERY_MATCH_THRESHOLD_PERCENT,
         skip_hashing: Annotated[Optional[bool], typer.Option(help="Skip perceptual hashing and just search for duplicates")] = False,
+        verify_cert: Annotated[Optional[bool], typer.Option(help="Require TLS cert to be verified for https")] = False,
         verbose:  Annotated[Optional[bool], typer.Option(hidden=True)] = False,
         debug: Annotated[Optional[bool], typer.Option(hidden=True)] = False,
         ):
@@ -70,7 +71,9 @@ def main(api_key: Annotated[Optional[str], typer.Option(help="Hydrus API Key")] 
     # Client connection
     # TODO: Try to connect with https first and then fallback to http with a strong warning
     _client = hydrus_api.Client(api_url=api_url,
-                                access_key=api_key)
+                                access_key=api_key,
+                                verify_cert=verify_cert,
+                                )
 
     error_connecting = True
     error_connecting_exception_msg = ""

--- a/src/hydrusvideodeduplicator/config.py
+++ b/src/hydrusvideodeduplicator/config.py
@@ -18,7 +18,7 @@ if in_wsl():
     from socket import gethostname
     _DEFAULT_IP = f"{gethostname()}.local"
 
-HYDRUS_API_URL=os.getenv("HYDRUS_API_URL", f"http://{_DEFAULT_IP}:{_DEFAULT_PORT}")
+HYDRUS_API_URL=os.getenv("HYDRUS_API_URL", f"https://{_DEFAULT_IP}:{_DEFAULT_PORT}")
 
 # Service name of where to store perceptual hash tag for video files
 HYDRUS_LOCAL_TAG_SERVICE_NAME=os.getenv("HYDRUS_LOCAL_TAG_SERVICE_NAME", "my tags")
@@ -30,3 +30,5 @@ DEDUP_DATABASE_DIR=Path(DEDUP_DATABASE_DIR)
 
 DEDUP_DATABASE_NAME=os.getenv("DEDUP_DATABASE_NAME", "videohashes")
 DEDUP_DATABASE_FILE=Path(DEDUP_DATABASE_DIR, f"{DEDUP_DATABASE_NAME}.sqlite")
+
+REQUESTS_CA_BUNDLE=os.getenv("REQUESTS_CA_BUNDLE")

--- a/src/hydrusvideodeduplicator/hydrus_api/__init__.py
+++ b/src/hydrusvideodeduplicator/hydrus_api/__init__.py
@@ -282,8 +282,7 @@ class Client:
         access_key: T.Optional[str] = None,
         api_url: str = DEFAULT_API_URL,
         session: T.Optional[requests.Session] = None,
-        verify_cert: T.Optional[bool] = False,
-        cert: T.Optional[str | tuple] = None,
+        verify_cert: T.Optional[str] = None, # Path to cert
     ) -> None:
         """
         See https://hydrusnetwork.github.io/hydrus/client_api.html for documentation.
@@ -292,7 +291,6 @@ class Client:
         self.access_key = access_key
         self.api_url = api_url.rstrip("/")
         self._verify_cert = verify_cert
-        self._cert = cert
         self.session = session or requests.Session()
 
     def _api_request(self, method: str, path: str, **kwargs: T.Any) -> requests.Response:
@@ -307,13 +305,12 @@ class Client:
             # Since we aren't using the json keyword-argument, we have to set the Content-Type manually
             kwargs["headers"]["Content-Type"] = "application/json"
 
-        if self._verify_cert == False:
+        if self._verify_cert == None:
             kwargs["verify"] = False
             requests.packages.urllib3.disable_warnings() 
+        else:
+            kwargs["verify"] = self._verify_cert
         
-        if self._cert != None:
-            kwargs["cert"] = self._cert
-
         try:
             response = self.session.request(method, self.api_url + path, **kwargs)
         except requests.RequestException as error:

--- a/src/hydrusvideodeduplicator/hydrus_api/__init__.py
+++ b/src/hydrusvideodeduplicator/hydrus_api/__init__.py
@@ -282,6 +282,8 @@ class Client:
         access_key: T.Optional[str] = None,
         api_url: str = DEFAULT_API_URL,
         session: T.Optional[requests.Session] = None,
+        verify_cert: T.Optional[bool] = False,
+        cert: T.Optional[str | tuple] = None,
     ) -> None:
         """
         See https://hydrusnetwork.github.io/hydrus/client_api.html for documentation.
@@ -289,6 +291,8 @@ class Client:
 
         self.access_key = access_key
         self.api_url = api_url.rstrip("/")
+        self._verify_cert = verify_cert
+        self._cert = cert
         self.session = session or requests.Session()
 
     def _api_request(self, method: str, path: str, **kwargs: T.Any) -> requests.Response:
@@ -302,6 +306,13 @@ class Client:
             kwargs["data"] = json.dumps(json_data, cls=_ABCJSONEncoder)
             # Since we aren't using the json keyword-argument, we have to set the Content-Type manually
             kwargs["headers"]["Content-Type"] = "application/json"
+
+        if self._verify_cert == False:
+            kwargs["verify"] = False
+            requests.packages.urllib3.disable_warnings() 
+        
+        if self._cert != None:
+            kwargs["cert"] = self._cert
 
         try:
             response = self.session.request(method, self.api_url + path, **kwargs)


### PR DESCRIPTION
Add `--verify-cert` option to pass a cert file to hydrus_api.

https is now assumed by default. If you don't use https just change your api-url.

Cert verification is disabled by default which is normally very bad but most people run local instances so it's okay. If you care enough to want to verify your cert, you will probably type `--help` or read the notice in the Usage section of the wiki.

Cert can also be read by the env variable `REQUESTS_CA_BUNDLE`

e.g. `REQUESTS_CA_BUNDLE=/path/to/your/certificate.pem`

These are all good defaults I think. I would like to balance security and usability. If people think this is not secure enough, I'll change it.