### PR TITLE
Add basic multiprocessing and cache duplicate search index

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -30,6 +30,8 @@ dependencies = [
     "hvdvpdq",
     "sqlitedict",
     "requests",
+    "psutil",
+    "joblib",
 ]
 
 [project.urls]

--- a/src/hydrusvideodeduplicator/__main__.py
+++ b/src/hydrusvideodeduplicator/__main__.py
@@ -30,7 +30,7 @@ def main(api_key: Annotated[Optional[str], typer.Option(help="Hydrus API Key")] 
         threshold: Annotated[Optional[float], typer.Option(help="Similarity threshold for a pair of videos where 100 is identical")] = VPDQ_QUERY_MATCH_THRESHOLD_PERCENT,
         skip_hashing: Annotated[Optional[bool], typer.Option(help="Skip perceptual hashing and just search for duplicates")] = False,
         verify_cert: Annotated[Optional[str], typer.Option(help="Path to TLS cert. This forces verification.")] = REQUESTS_CA_BUNDLE,
-        clear_search_cache: Annotated[Optional[bool], typer.Option(help="Clear the cache that tracks what files have already been compared. Does not clear perceptual hashes.")] = False,
+        clear_search_cache: Annotated[Optional[bool], typer.Option(help="Clear the cache that tracks what files have already been compared")] = False,
         verbose:  Annotated[Optional[bool], typer.Option(help="Verbose logging")] = False,
         debug: Annotated[Optional[bool], typer.Option(hidden=True)] = False,
         ):

--- a/src/hydrusvideodeduplicator/__main__.py
+++ b/src/hydrusvideodeduplicator/__main__.py
@@ -30,6 +30,7 @@ def main(api_key: Annotated[Optional[str], typer.Option(help="Hydrus API Key")] 
         threshold: Annotated[Optional[float], typer.Option(help="Similarity threshold for a pair of videos where 100 is identical")] = VPDQ_QUERY_MATCH_THRESHOLD_PERCENT,
         skip_hashing: Annotated[Optional[bool], typer.Option(help="Skip perceptual hashing and just search for duplicates")] = False,
         verify_cert: Annotated[Optional[str], typer.Option(help="Path to TLS cert. This forces verification.")] = REQUESTS_CA_BUNDLE,
+        clear_search_cache: Annotated[Optional[bool], typer.Option(help="Clear the cache that tracks what files have already been compared. Does not clear perceptual hashes.")] = False,
         verbose:  Annotated[Optional[bool], typer.Option(help="Verbose logging")] = False,
         debug: Annotated[Optional[bool], typer.Option(hidden=True)] = False,
         ):
@@ -51,6 +52,11 @@ def main(api_key: Annotated[Optional[str], typer.Option(help="Hydrus API Key")] 
     # Logs are separate from printing in this program.
     if not verbose:
         logging.disable()
+
+    # Clear cache
+    if clear_search_cache:
+        HydrusVideoDeduplicator.clear_search_cache()
+        rprint("[green] Cleared search cache.")
 
     # CLI overwrites env vars
     if not api_key:

--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -230,6 +230,7 @@ class HydrusVideoDeduplicator():
             # TODO: Defer this API call to speed up processing
             self.client.set_file_relationships([new_relationship])
     
+    # Delete cache row in database
     @staticmethod
     def clear_search_cache():
         try:
@@ -281,10 +282,11 @@ class HydrusVideoDeduplicator():
                             row["farthest_search_index"] = len(hashdb)-1
                             hashdb[video1_hash] = row
 
+                            count_since_last_commit+=1
+
                             if count_since_last_commit >= commit_interval:
                                 hashdb.commit()
                                 count_since_last_commit = 0
-                            count_since_last_commit+=1
 
             except KeyboardInterrupt:
                 pass

--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -227,7 +227,6 @@ class HydrusVideoDeduplicator():
                 "do_default_content_merge": True,
             }
         
-            # TODO: Defer this API call to speed up processing
             self.client.set_file_relationships([new_relationship])
     
     # Delete cache row in database

--- a/src/hydrusvideodeduplicator/dedup.py
+++ b/src/hydrusvideodeduplicator/dedup.py
@@ -275,6 +275,10 @@ class HydrusVideoDeduplicator():
                             row = hashdb[video1_hash]
                             row.setdefault("farthest_search_index", i+1)
 
+                            # This is not necessary but may increase speed by avoiding any of the code below
+                            if row["farthest_search_index"] >= len(hashdb)-1:
+                                continue
+
                             parallel(delayed(self.compare_videos)(video1_hash, video2_hash, hashdb[video1_hash]["perceptual_hash"], hashdb[video2_hash]["perceptual_hash"]) for video2_hash in islice(hashdb, row["farthest_search_index"], None))
 
                             # Update furthest search position to the current length of the table

--- a/src/hydrusvideodeduplicator/dedup_util.py
+++ b/src/hydrusvideodeduplicator/dedup_util.py
@@ -3,6 +3,9 @@ from datetime import datetime
 import time
 import os
 import contextlib
+from pathlib import Path
+from sqlitedict import SqliteDict
+from rich import print as rprint
 
 from hydrusvideodeduplicator.hydrus_api import Client
  
@@ -134,3 +137,16 @@ class ThreadSafeCounter():
     def value(self):
         with self._lock:
             return self._counter
+
+def database_accessible(db_file: Path | str, tablename: str):
+    try:
+        with SqliteDict(str(db_file), tablename=tablename, flag="r"):
+            return True
+    except OSError:
+        rprint(f"[red] Database does not exist. Cannot search for duplicates.")
+    except RuntimeError: # SqliteDict error when trying to create a table for a DB in read-only mode
+        rprint(f"[red] Database does not exist. Cannot search for duplicates.")
+    except Exception as exc:
+        rprint(f"[red] Could not access database.")
+        logging.error(str(exc))
+    return False

--- a/src/hydrusvideodeduplicator/dedup_util.py
+++ b/src/hydrusvideodeduplicator/dedup_util.py
@@ -112,3 +112,25 @@ def getDuration(then, now = datetime.now(), interval = "default"):
         'seconds': int(seconds()),
         'default': totalDuration()
     }[interval]        
+
+from threading import Thread
+from threading import Lock
+ 
+# thread safe counter class
+class ThreadSafeCounter():
+    # constructor
+    def __init__(self):
+        # initialize counter
+        self._counter = 0
+        # initialize lock
+        self._lock = Lock()
+ 
+    # increment the counter
+    def increment(self):
+        with self._lock:
+            self._counter += 1
+ 
+    # get the counter value
+    def value(self):
+        with self._lock:
+            return self._counter


### PR DESCRIPTION
Multiprocessing is done by joblib. It could be set as an optional dependency, but it seems fairly portable and I don't want to support multiple solutions right now.

Added a cache for each file to search for the last index compared similarity to avoid rechecking on multiple runs. This assumes the Python dict is ordered, of course.

With the cache, if you change the threshold you need to clear the cache if you want to recheck previously compared videos, so I added the `--clear-search-cache` CLI option.